### PR TITLE
Remove deprecated Homebrew method call

### DIFF
--- a/spacebar.rb
+++ b/spacebar.rb
@@ -12,7 +12,6 @@ class Spacebar < Formula
     (var/"log/spacebar").mkpath
     man.mkpath
 
-    ENV.O2
     system "make", "install"
 
     bin.install "#{buildpath}/bin/spacebar"


### PR DESCRIPTION
Remove deprecated `ENV.O2` optimisation method call.

Has been tested locally.

Original issue https://github.com/cmacrae/spacebar/issues/52.
Solution inspired by https://github.com/Homebrew/homebrew-core/issues/70594.
